### PR TITLE
Add speech synthesis and pinch-to-zoom functionality

### DIFF
--- a/XVisionBoardAI/Services/SpeechManager.swift
+++ b/XVisionBoardAI/Services/SpeechManager.swift
@@ -1,0 +1,26 @@
+//
+//  SpeechManager.swift
+//  XVisionBoardAI
+//
+//  Created by AI Assistant
+//  Copyright © 2025 XVisionBoard AI. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+
+@MainActor
+class SpeechManager: ObservableObject {
+    private let synthesizer = AVSpeechSynthesizer()
+
+    func speak(_ text: String) {
+        stop()
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        synthesizer.speak(utterance)
+    }
+
+    func stop() {
+        synthesizer.stopSpeaking(at: .immediate)
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SpeechManager` to provide text-to-speech playback
- hook up Read Aloud button to speak current affirmation and stop speech on exit
- replace stubbed `pinchToZoom` with working magnification gesture

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68918a7e5c808329977d1b8472348959