### PR TITLE
Fix remaining vision board calculation

### DIFF
--- a/XVisionBoardAI/ViewModels/UserManager.swift
+++ b/XVisionBoardAI/ViewModels/UserManager.swift
@@ -177,8 +177,8 @@ class UserManager: ObservableObject {
     
     var remainingVisionBoards: Int {
         guard let user = currentUser else { return 0 }
-        let max = user.maxVisionBoards
-        return max == -1 ? Int.max : max(0, max - user.visionBoardCount)
+        let maxBoards = user.maxVisionBoards
+        return maxBoards == -1 ? Int.max : Swift.max(0, maxBoards - user.visionBoardCount)
     }
     
     var subscriptionDisplayName: String {


### PR DESCRIPTION
## Summary
- Avoid variable shadowing when computing remaining vision boards
- Use `Swift.max` for correct calculation of remaining board allowance

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftc -typecheck XVisionBoardAI/ViewModels/UserManager.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68918bdb33288329aee25b616f71f458