### PR TITLE
Centralize debug setup and streamline directives

### DIFF
--- a/Utils/DebugHelper.swift
+++ b/Utils/DebugHelper.swift
@@ -1,0 +1,9 @@
+#if DEBUG
+import Foundation
+
+/// Performs debug-only setup such as loading mock data or enabling logging.
+func configureDebugEnvironment() {
+    // Add debug-only initialization tasks here.
+    print("Debug environment configured")
+}
+#endif

--- a/XVisionBoardAIApp.swift
+++ b/XVisionBoardAIApp.swift
@@ -22,6 +22,9 @@ struct XVisionBoardAIApp: App {
                 .environmentObject(userManager)
                 .environmentObject(visionBoardManager)
                 .onAppear {
+                    #if DEBUG && targetEnvironment(simulator)
+                    configureDebugEnvironment()
+                    #endif
                     // Initialize app services
                     Task {
                         await storeManager.loadProducts()


### PR DESCRIPTION
## Summary
- Add `DebugHelper` to consolidate debug-only initialization
- Streamline conditional compilation with `#if DEBUG && targetEnvironment(simulator)` in app entry

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a63ee63af883298fa19fe577e50e94