### PR TITLE
Add Sora API integration

### DIFF
--- a/Models/SoraVideo.swift
+++ b/Models/SoraVideo.swift
@@ -1,0 +1,59 @@
+//
+//  SoraVideo.swift
+//  XVisionBoardAI
+//
+//  Created by AI Assistant
+//  Copyright © 2025 XVisionBoard AI. All rights reserved.
+//
+
+import Foundation
+
+enum SoraJobStatus: String, Codable {
+    case queued
+    case processing
+    case succeeded
+    case failed
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        self = SoraJobStatus(rawValue: value) ?? .unknown
+    }
+}
+
+struct SoraVideoAsset: Codable {
+    let jobId: String
+    var status: SoraJobStatus
+    var downloadURL: String?
+    var thumbnailURL: String?
+    var prompt: String
+    var createdAt: Date
+    var lastUpdated: Date
+
+    init(
+        jobId: String,
+        status: SoraJobStatus,
+        downloadURL: String? = nil,
+        thumbnailURL: String? = nil,
+        prompt: String,
+        createdAt: Date = Date(),
+        lastUpdated: Date = Date()
+    ) {
+        self.jobId = jobId
+        self.status = status
+        self.downloadURL = downloadURL
+        self.thumbnailURL = thumbnailURL
+        self.prompt = prompt
+        self.createdAt = createdAt
+        self.lastUpdated = lastUpdated
+    }
+
+    var isReady: Bool {
+        status == .succeeded && downloadURL != nil
+    }
+
+    var isInProgress: Bool {
+        status == .queued || status == .processing
+    }
+}

--- a/Models/VisionBoard.swift
+++ b/Models/VisionBoard.swift
@@ -26,6 +26,7 @@ struct VisionBoard: Codable, Identifiable {
     var manifestationGoals: [String]
     var viewCount: Int
     var isFavorite: Bool
+    var soraVideo: SoraVideoAsset?
 
     init(
         title: String,
@@ -48,6 +49,7 @@ struct VisionBoard: Codable, Identifiable {
         self.manifestationGoals = []
         self.viewCount = 0
         self.isFavorite = false
+        self.soraVideo = nil
     }
 
     var userImage: UIImage? {
@@ -99,6 +101,12 @@ extension VisionBoard {
             ]
             $0.isFavorite = true
             $0.viewCount = 42
+            $0.soraVideo = SoraVideoAsset(
+                jobId: "sample-job",
+                status: .succeeded,
+                downloadURL: "https://example.com/video.mp4",
+                prompt: "Cinematic manifestation sequence"
+            )
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ for in-app subscriptions.
 2. Select the `XVisionBoardAI` target.
 3. Build and run the app on an iOS 17 simulator or device.
 
+### Sora API (video generation)
+
+Sora-powered video previews are supported through the `SoraAPIClient`. To enable them, provide credentials via either **Info.plist** entries or environment variables:
+
+- `SORA_API_KEY` (required)
+- `SORA_BASE_URL` (defaults to `https://api.openai.com/v1`)
+- `SORA_ORG_ID` (optional)
+- `SORA_PROJECT_ID` (optional)
+
+Without these values the app will continue to work, but Sora video generation buttons will show a configuration error.
+
 ## Contributing
 
 Contributions are welcome! Feel free to fork the repository and open a pull request with your changes.
@@ -26,4 +37,3 @@ Contributions are welcome! Feel free to fork the repository and open a pull requ
 ## License
 
 This project is released under the MIT License. See the `LICENSE` file for more information if available.
-

--- a/Services/SoraAPI.swift
+++ b/Services/SoraAPI.swift
@@ -1,0 +1,190 @@
+//
+//  SoraAPI.swift
+//  XVisionBoardAI
+//
+//  Created by AI Assistant
+//  Copyright © 2025 XVisionBoard AI. All rights reserved.
+//
+
+import Foundation
+
+struct SoraAPIConfiguration {
+    let apiKey: String
+    let organization: String?
+    let project: String?
+    let baseURL: URL
+
+    static func fromEnvironment(bundle: Bundle = .main) -> SoraAPIConfiguration? {
+        let environment = ProcessInfo.processInfo.environment
+
+        let apiKey = environment["SORA_API_KEY"] ?? bundle.object(forInfoDictionaryKey: "SORA_API_KEY") as? String
+        guard let apiKey else { return nil }
+
+        let baseURLString = environment["SORA_BASE_URL"] ??
+            bundle.object(forInfoDictionaryKey: "SORA_BASE_URL") as? String ??
+            "https://api.openai.com/v1"
+
+        guard let baseURL = URL(string: baseURLString) else { return nil }
+
+        let organization = environment["SORA_ORG_ID"] ?? bundle.object(forInfoDictionaryKey: "SORA_ORG_ID") as? String
+        let project = environment["SORA_PROJECT_ID"] ?? bundle.object(forInfoDictionaryKey: "SORA_PROJECT_ID") as? String
+
+        return SoraAPIConfiguration(
+            apiKey: apiKey,
+            organization: organization,
+            project: project,
+            baseURL: baseURL
+        )
+    }
+}
+
+struct SoraVideoRequest: Encodable {
+    let prompt: String
+    let model: String
+    let duration: Int
+    let aspectRatio: String
+    let resolution: String
+    let referenceImage: String?
+
+    enum CodingKeys: String, CodingKey {
+        case prompt
+        case model
+        case duration
+        case aspectRatio = "aspect_ratio"
+        case resolution
+        case referenceImage = "reference_image"
+    }
+}
+
+struct SoraVideoResponse: Decodable {
+    let id: String
+    let status: SoraJobStatus
+    let downloadURL: URL?
+    let thumbnailURL: URL?
+    let eta: Int?
+    let message: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case status
+        case downloadURL = "download_url"
+        case thumbnailURL = "thumbnail_url"
+        case eta
+        case message
+    }
+}
+
+struct SoraAPIErrorResponse: Decodable {
+    struct APIError: Decodable {
+        let message: String
+    }
+
+    let error: APIError?
+}
+
+enum SoraAPIError: LocalizedError {
+    case missingConfiguration
+    case invalidURL
+    case invalidResponse
+    case server(String)
+    case decoding(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingConfiguration:
+            return "Sora API is not configured."
+        case .invalidURL:
+            return "The Sora API URL is invalid."
+        case .invalidResponse:
+            return "The Sora API returned an unexpected response."
+        case .server(let message):
+            return message
+        case .decoding(let error):
+            return "Failed to decode Sora response: \(error.localizedDescription)"
+        }
+    }
+}
+
+final class SoraAPIClient {
+    private let configuration: SoraAPIConfiguration
+    private let session: URLSession
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init?(configuration: SoraAPIConfiguration?) {
+        guard let configuration else { return nil }
+        self.configuration = configuration
+        self.session = URLSession(configuration: .default)
+        self.encoder = JSONEncoder()
+        self.decoder = JSONDecoder()
+        self.decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func generateVideo(
+        prompt: String,
+        duration: Int = 10,
+        aspectRatio: String = "16:9",
+        resolution: String = "1280x720",
+        referenceImageData: Data?
+    ) async throws -> SoraVideoResponse {
+        let requestBody = SoraVideoRequest(
+            prompt: prompt,
+            model: "sora-1.1",
+            duration: duration,
+            aspectRatio: aspectRatio,
+            resolution: resolution,
+            referenceImage: referenceImageData?.base64EncodedString()
+        )
+
+        var request = try makeRequest(path: "videos", method: "POST")
+        request.httpBody = try encoder.encode(requestBody)
+
+        let (data, response) = try await session.data(for: request)
+        return try decodeResponse(data: data, response: response)
+    }
+
+    func fetchVideoStatus(id: String) async throws -> SoraVideoResponse {
+        let request = try makeRequest(path: "videos/\(id)", method: "GET")
+        let (data, response) = try await session.data(for: request)
+        return try decodeResponse(data: data, response: response)
+    }
+    
+    private func makeRequest(path: String, method: String) throws -> URLRequest {
+        let url = configuration.baseURL.appendingPathComponent(path)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+
+        if let organization = configuration.organization {
+            request.setValue(organization, forHTTPHeaderField: "OpenAI-Organization")
+        }
+
+        if let project = configuration.project {
+            request.setValue(project, forHTTPHeaderField: "OpenAI-Project")
+        }
+
+        return request
+    }
+
+    private func decodeResponse<T: Decodable>(data: Data, response: URLResponse) throws -> T {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SoraAPIError.invalidResponse
+        }
+
+        if !(200...299).contains(httpResponse.statusCode) {
+            if let errorResponse = try? decoder.decode(SoraAPIErrorResponse.self, from: data),
+               let message = errorResponse.error?.message {
+                throw SoraAPIError.server(message)
+            }
+            throw SoraAPIError.invalidResponse
+        }
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw SoraAPIError.decoding(error)
+        }
+    }
+}

--- a/ViewModels/VisionBoardManager.swift
+++ b/ViewModels/VisionBoardManager.swift
@@ -17,11 +17,14 @@ class VisionBoardManager: ObservableObject {
     @Published var generationProgress: Double = 0.0
     @Published var errorMessage: String?
     @Published var currentGeneratingBoard: VisionBoard?
+    @Published var isRequestingSoraVideo = false
     
     private let userDefaults = UserDefaults.standard
     private let visionBoardsKey = "savedVisionBoards"
+    private let soraAPI: SoraAPIClient?
     
-    init() {
+    init(soraAPI: SoraAPIClient? = nil) {
+        self.soraAPI = soraAPI ?? SoraAPIClient(configuration: .fromEnvironment())
         loadVisionBoards()
     }
     
@@ -219,6 +222,107 @@ class VisionBoardManager: ObservableObject {
         }
     }
     
+    // MARK: - Sora Video Generation
+    
+    func generateSoraVideo(for visionBoard: VisionBoard) async -> SoraVideoAsset? {
+        errorMessage = nil
+        
+        guard let soraAPI else {
+            errorMessage = "Sora API key is missing. Add SORA_API_KEY to your Info.plist or environment."
+            return nil
+        }
+        
+        guard let index = visionBoards.firstIndex(where: { $0.id == visionBoard.id }) else {
+            errorMessage = "Vision board could not be found."
+            return nil
+        }
+        
+        isRequestingSoraVideo = true
+        defer { isRequestingSoraVideo = false }
+        
+        do {
+            let prompt = soraPrompt(for: visionBoard)
+            let response = try await soraAPI.generateVideo(
+                prompt: prompt,
+                duration: 12,
+                aspectRatio: "16:9",
+                resolution: "1280x720",
+                referenceImageData: visionBoard.userImageData
+            )
+            
+            var soraAsset = SoraVideoAsset(
+                jobId: response.id,
+                status: response.status,
+                downloadURL: response.downloadURL?.absoluteString,
+                thumbnailURL: response.thumbnailURL?.absoluteString,
+                prompt: prompt,
+                createdAt: Date(),
+                lastUpdated: Date()
+            )
+            
+            visionBoards[index].soraVideo = soraAsset
+            saveVisionBoards()
+            
+            // Update with any immediate status change
+            if let refreshed = await refreshSoraVideoStatus(for: visionBoard) {
+                soraAsset = refreshed
+            }
+            
+            return soraAsset
+        } catch {
+            errorMessage = "Sora video generation failed: \(error.localizedDescription)"
+            return nil
+        }
+    }
+    
+    func refreshSoraVideoStatus(for visionBoard: VisionBoard) async -> SoraVideoAsset? {
+        errorMessage = nil
+        
+        guard let soraAPI else {
+            errorMessage = "Sora API is not configured."
+            return visionBoard.soraVideo
+        }
+        
+        let storedBoard = visionBoards.first(where: { $0.id == visionBoard.id })
+        guard var soraAsset = storedBoard?.soraVideo ?? visionBoard.soraVideo else {
+            errorMessage = "No Sora video request found for this vision board."
+            return nil
+        }
+        
+        do {
+            let response = try await soraAPI.fetchVideoStatus(id: soraAsset.jobId)
+            soraAsset.status = response.status
+            soraAsset.downloadURL = response.downloadURL?.absoluteString ?? soraAsset.downloadURL
+            soraAsset.thumbnailURL = response.thumbnailURL?.absoluteString ?? soraAsset.thumbnailURL
+            soraAsset.lastUpdated = Date()
+            
+            if let index = visionBoards.firstIndex(where: { $0.id == visionBoard.id }) {
+                visionBoards[index].soraVideo = soraAsset
+                saveVisionBoards()
+            }
+            
+            return soraAsset
+        } catch {
+            errorMessage = "Failed to refresh Sora status: \(error.localizedDescription)"
+            return soraAsset
+        }
+    }
+    
+    private func soraPrompt(for visionBoard: VisionBoard) -> String {
+        var components: [String] = [
+            visionBoard.description,
+            "Create a short cinematic motion clip where the user confidently appears in each frame, celebrating their wins."
+        ]
+        
+        if !visionBoard.manifestationGoals.isEmpty {
+            components.append("Goals: \(visionBoard.manifestationGoals.joined(separator: \", \")).")
+        }
+        
+        components.append("Style: \(visionBoard.style.displayName) with \(visionBoard.layout.displayName) framing.")
+        
+        return components.joined(separator: " ")
+    }
+    
     // MARK: - Vision Board Management
     
     func deleteVisionBoard(_ visionBoard: VisionBoard) {
@@ -286,4 +390,3 @@ class VisionBoardManager: ObservableObject {
         visionBoards.reduce(0) { $0 + $1.viewCount }
     }
 }
-

--- a/Views/VisionBoardDetailView.swift
+++ b/Views/VisionBoardDetailView.swift
@@ -20,6 +20,9 @@ struct VisionBoardDetailView: View {
     @State private var showingFullScreenImage: VisionBoardImage?
     @State private var currentAffirmationIndex = 0
     @State private var affirmationTimer: Timer?
+    @State private var soraVideo: SoraVideoAsset?
+    @State private var isGeneratingSoraVideo = false
+    @State private var soraStatusMessage: String?
     
     var body: some View {
         NavigationView {
@@ -41,6 +44,9 @@ struct VisionBoardDetailView: View {
                         if !visionBoard.manifestationGoals.isEmpty {
                             goalsSection
                         }
+                        
+                        // Sora video
+                        soraVideoSection
                         
                         // Actions
                         actionsSection
@@ -110,6 +116,7 @@ struct VisionBoardDetailView: View {
         }
         .onAppear {
             startAffirmationTimer()
+            soraVideo = visionBoard.soraVideo
         }
         .onDisappear {
             stopAffirmationTimer()
@@ -312,6 +319,73 @@ struct VisionBoardDetailView: View {
         }
     }
     
+    // MARK: - Sora Video Section
+    
+    private var soraVideoSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Sora Video (Beta)")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .foregroundColor(.cosmicWhite)
+                
+                Spacer()
+                
+                if let soraVideo {
+                    SoraStatusBadge(status: soraVideo.status)
+                }
+            }
+            
+            Text("Generate a short Sora video that visualizes you achieving this vision.")
+                .manifestationBody()
+                .multilineTextAlignment(.leading)
+            
+            if let soraVideo {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Status: \(soraStatusDescription(for: soraVideo.status))")
+                        .font(.subheadline)
+                        .foregroundColor(.cosmicWhite.opacity(0.9))
+                    
+                    if let download = soraVideo.downloadURL, let url = URL(string: download), soraVideo.isReady {
+                        Link("Open Sora Video", destination: url)
+                            .cosmicButton()
+                    } else if soraVideo.isInProgress {
+                        Text("Your video is still rendering. Tap refresh to check for updates.")
+                            .font(.caption)
+                            .foregroundColor(.cosmicWhite.opacity(0.7))
+                    }
+                }
+            }
+            
+            if let soraStatusMessage {
+                Text(soraStatusMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+            
+            HStack(spacing: 12) {
+                if isGeneratingSoraVideo {
+                    ProgressView("Contacting Sora...")
+                        .progressViewStyle(CircularProgressViewStyle(tint: .cosmicPurple))
+                        .foregroundColor(.cosmicWhite)
+                } else if let soraVideo {
+                    Button("Refresh Sora Status") {
+                        refreshSoraStatus()
+                    }
+                    .cosmicButton()
+                    .disabled(soraVideo.status == .succeeded)
+                } else {
+                    Button("Generate Sora Video") {
+                        requestSoraVideo()
+                    }
+                    .cosmicButton()
+                }
+            }
+        }
+        .padding()
+        .cosmicCard()
+    }
+    
     // MARK: - Actions Section
     
     private var actionsSection: some View {
@@ -360,6 +434,61 @@ struct VisionBoardDetailView: View {
     
     // MARK: - Helper Methods
     
+    private func requestSoraVideo() {
+        Task {
+            await MainActor.run {
+                isGeneratingSoraVideo = true
+                soraStatusMessage = nil
+            }
+            
+            let asset = await visionBoardManager.generateSoraVideo(for: visionBoard)
+            
+            await MainActor.run {
+                soraVideo = asset ?? soraVideo
+                isGeneratingSoraVideo = false
+                
+                if asset == nil {
+                    soraStatusMessage = visionBoardManager.errorMessage ?? "Unable to start Sora video."
+                }
+            }
+        }
+    }
+    
+    private func refreshSoraStatus() {
+        Task {
+            await MainActor.run {
+                isGeneratingSoraVideo = true
+                soraStatusMessage = nil
+            }
+            
+            let asset = await visionBoardManager.refreshSoraVideoStatus(for: visionBoard)
+            
+            await MainActor.run {
+                soraVideo = asset ?? soraVideo
+                isGeneratingSoraVideo = false
+                
+                if asset == nil {
+                    soraStatusMessage = visionBoardManager.errorMessage ?? "No Sora video to refresh."
+                }
+            }
+        }
+    }
+    
+    private func soraStatusDescription(for status: SoraJobStatus) -> String {
+        switch status {
+        case .queued:
+            return "Queued"
+        case .processing:
+            return "Processing"
+        case .succeeded:
+            return "Ready"
+        case .failed:
+            return "Failed"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+    
     private func startAffirmationTimer() {
         guard !visionBoard.affirmations.isEmpty else { return }
         
@@ -405,6 +534,36 @@ struct InfoBadge: View {
                 .font(.caption)
                 .foregroundColor(.cosmicWhite.opacity(0.8))
         }
+    }
+}
+
+struct SoraStatusBadge: View {
+    let status: SoraJobStatus
+    
+    private var style: (text: String, color: Color) {
+        switch status {
+        case .queued:
+            return ("Queued", .yellow)
+        case .processing:
+            return ("Processing", .cosmicPurple)
+        case .succeeded:
+            return ("Ready", .green)
+        case .failed:
+            return ("Failed", .red)
+        case .unknown:
+            return ("Unknown", .gray)
+        }
+    }
+    
+    var body: some View {
+        Text(style.text)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(style.color.opacity(0.2))
+            .foregroundColor(style.color)
+            .clipShape(Capsule())
     }
 }
 
@@ -627,4 +786,3 @@ extension View {
     VisionBoardDetailView(visionBoard: VisionBoard.sampleVisionBoard)
         .environmentObject(VisionBoardManager())
 }
-

--- a/XVisionBoardAI.xcodeproj/project.pbxproj
+++ b/XVisionBoardAI.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		135 /* Services/StoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134 /* Services/StoreManager.swift */; };
 137 /* Services/CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136 /* Services/CameraManager.swift */; };
 138 /* Services/TokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139 /* Services/TokenStore.swift */; };
+B2D1F0A32F4F4C4B00D7E6C1 /* Services/SoraAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D1F0A22F4F4C4B00D7E6C1 /* Services/SoraAPI.swift */; };
+B2D1F0A52F4F4C4B00D7E6C1 /* Models/SoraVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D1F0A12F4F4C4B00D7E6C1 /* Models/SoraVideo.swift */; };
 B21BEFA02E43409E00EDBF92 /* SpeechManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21BEF9F2E43409E00EDBF92 /* SpeechManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -51,9 +53,11 @@ B21BEFA02E43409E00EDBF92 /* SpeechManager.swift in Sources */ = {isa = PBXBuildF
 		134 /* Services/StoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/StoreManager.swift; sourceTree = "<group>"; };
 136 /* Services/CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/CameraManager.swift; sourceTree = "<group>"; };
 139 /* Services/TokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/TokenStore.swift; sourceTree = "<group>"; };
-7 /* XVisionBoardAI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = XVisionBoardAI.app; sourceTree = BUILT_PRODUCTS_DIR; };
-B21BEF9E2E4338C700EDBF92 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-B21BEF9F2E43409E00EDBF92 /* SpeechManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SpeechManager.swift; path = Services/SpeechManager.swift; sourceTree = "<group>"; };
+		B2D1F0A12F4F4C4B00D7E6C1 /* Models/SoraVideo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/SoraVideo.swift; sourceTree = "<group>"; };
+		B2D1F0A22F4F4C4B00D7E6C1 /* Services/SoraAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/SoraAPI.swift; sourceTree = "<group>"; };
+		7 /* XVisionBoardAI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = XVisionBoardAI.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B21BEF9E2E4338C700EDBF92 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B21BEF9F2E43409E00EDBF92 /* SpeechManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SpeechManager.swift; path = Services/SpeechManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -66,6 +70,7 @@ B21BEF9F2E43409E00EDBF92 /* SpeechManager.swift */ = {isa = PBXFileReference; fi
 				102 /* ViewModels/VisionBoardManager.swift */,
 				104 /* ViewModels/UserManager.swift */,
 				110 /* Models/VisionBoard.swift */,
+				B2D1F0A12F4F4C4B00D7E6C1 /* Models/SoraVideo.swift */,
 				106 /* Utils/ColorScheme.swift */,
 				112 /* Models/User.swift */,
 				114 /* Views/VisionBoardGalleryView.swift */,
@@ -82,6 +87,7 @@ B21BEF9F2E43409E00EDBF92 /* SpeechManager.swift */ = {isa = PBXFileReference; fi
 134 /* Services/StoreManager.swift */,
 136 /* Services/CameraManager.swift */,
 139 /* Services/TokenStore.swift */,
+				B2D1F0A22F4F4C4B00D7E6C1 /* Services/SoraAPI.swift */,
 );
 sourceTree = "<group>";
 };
@@ -164,6 +170,8 @@ sourceTree = "<group>";
 135 /* Services/StoreManager.swift in Sources */,
 137 /* Services/CameraManager.swift in Sources */,
 138 /* Services/TokenStore.swift in Sources */,
+B2D1F0A32F4F4C4B00D7E6C1 /* Services/SoraAPI.swift in Sources */,
+B2D1F0A52F4F4C4B00D7E6C1 /* Models/SoraVideo.swift in Sources */,
 );
 runOnlyForDeploymentPostprocessing = 0;
 };


### PR DESCRIPTION
## Summary
- add a reusable Sora API client plus request/response models for video rendering
- extend vision boards and their manager to track Sora jobs and refresh status
- surface a Sora video section in the detail view and document the required configuration keys

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69488b1e26408329b2e6866bfd7a8013)